### PR TITLE
Sets client defaults to true

### DIFF
--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -39,14 +39,5 @@ docker_daemon_options:
 # role: ethpandaops.general.prometheus
 prometheus_container_networks: "{{ docker_networks_shared }}"
 
-# role: sets various defaults for all the ethereum client roles
-besu_container_pull: true
-erigon_container_pull: true
-ethereumjs_container_pull: true
-geth_container_pull: true
-lighthouse_container_pull: true
-lodestar_container_pull: true
-nethermind_container_pull: true
-nimbus_container_pull: true
-prysm_container_pull: true
-teku_container_pull: true
+# role: ethpandaops.general.ethereum_node
+ethereum_node_images_always_pull: true

--- a/ansible/group_vars/all/defaults.yaml
+++ b/ansible/group_vars/all/defaults.yaml
@@ -38,3 +38,15 @@ docker_daemon_options:
 
 # role: ethpandaops.general.prometheus
 prometheus_container_networks: "{{ docker_networks_shared }}"
+
+# role: sets various defaults for all the ethereum client roles
+besu_container_pull: true
+erigon_container_pull: true
+ethereumjs_container_pull: true
+geth_container_pull: true
+lighthouse_container_pull: true
+lodestar_container_pull: true
+nethermind_container_pull: true
+nimbus_container_pull: true
+prysm_container_pull: true
+teku_container_pull: true


### PR DESCRIPTION
The reason for the PR is that if testnets use the same image tag, then the image is definitely updated. We had an issue where I left it at the default and then deposit-devnets was handed over to an external party who reused the same tags. That led to a ton of wasted time debugging issues where the image was never updated.

This PR would ensure that future testnets built from this testnet won't have the issue. 

Reminder: If we ever add support for new clients, we should definitely add the pull policy to true for them as well. 